### PR TITLE
Switch to SAPBERT qdrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # benchmarks
 Benchmarks and results in comparing between NER engines
+
+## Running the comparator
+
+You can run the comparator by using [pdm](https://pdm-project.org/en/latest/):
+
+```shell
+$ pdm run comparator data/2024jun5/name_res_inputs-2024may30.csv --query='query' --biolink-type='biolink_type' --output data/2024jun5/output.csv
+```

--- a/comparator/cli.py
+++ b/comparator/cli.py
@@ -80,6 +80,8 @@ def comparator(input_file, output, query, biolink_type, engines, csv_dialect):
             logging.warning(f"Type field '{biolink_type}' not found in CSV row: {row}")
             continue
         text_type = row.get(biolink_type, '')
+        if text_type.strip().lower() in {'na', 'none', 'entity', 'biolink:entity', 'namedthing', 'biolink:namedthing'}:
+            text_type = ''
 
         # Get top NameRes result.
         nameres_results = []

--- a/comparator/cli.py
+++ b/comparator/cli.py
@@ -31,7 +31,9 @@ logging.basicConfig(level=logging.INFO)
 @click.option('engines', '--engine', '-e', type=str, multiple=True, help='The engines to compare')
 @click.option('--csv-dialect', type=click.Choice(csv.list_dialects(), case_sensitive=False),
               help='The CSV dialect to use (see the Python `csv` module for options).')
-def comparator(input_file, output, query, biolink_type, engines, csv_dialect):
+@click.option('continue_filename', '--continue', type=click.Path(exists=True, readable=True),
+              help='An output file which we can continue working on by loading already completed work.')
+def comparator(input_file, output, query, biolink_type, engines, csv_dialect, continue_filename):
     """
     Run one or more NERs on an input file and produce comparative results.
 
@@ -39,6 +41,17 @@ def comparator(input_file, output, query, biolink_type, engines, csv_dialect):
 
     INPUT_FILE: the file to process. Use '-' to use the standard input stream.
     """
+
+    # Read the continue filename. We need to read this and then close the file, because it is probably the
+    # same file as the output file!
+    result_cache = dict()
+    with open(click.format_filename(continue_filename), 'r') as continuef:
+        continue_file_reader = csv.DictReader(continuef, dialect=csv_dialect)
+        for row in continue_file_reader:
+            if query not in row:
+                # This is the cache, anyway. Ignore.
+                continue
+            result_cache[row[query]] = row
 
     # Set up a repeatable session.
     session = requests.Session()
@@ -75,6 +88,11 @@ def comparator(input_file, output, query, biolink_type, engines, csv_dialect):
             logging.error(f"Query field '{query}' not found in CSV row: {row}")
             continue
         text = row[query]
+
+        # Do we have this text cached?
+        if text in result_cache:
+            csv_writer.writerow(result_cache[text])
+            continue
 
         if biolink_type not in row:
             logging.warning(f"Type field '{biolink_type}' not found in CSV row: {row}")

--- a/comparator/engines/sapbert.py
+++ b/comparator/engines/sapbert.py
@@ -28,6 +28,10 @@ class SAPBERTNEREngine(BaseNEREngine):
     def annotate(self, text, props, limit=1):
         biolink_type = props.get('biolink_type', '')
 
+        # SAPBERT-Qdrant requires Biolink types that start with 'biolink:'
+        if biolink_type != '' and not biolink_type.startswith('biolink:'):
+            biolink_type = f"biolink:{biolink_type}"
+
         # Make a request to Nemo-Serve.
         request = {
             "text": text,

--- a/comparator/engines/sapbert.py
+++ b/comparator/engines/sapbert.py
@@ -7,7 +7,7 @@ import requests
 from comparator.engines.base import BaseNEREngine
 
 # Configuration: get the SAPBERT URL and figure out the annotate path.
-SAPBERT_URL = os.getenv('SAPBERT_URL', 'https://babel-sapbert.apps.renci.org/')
+SAPBERT_URL = os.getenv('SAPBERT_URL', 'https://sap-qdrant.apps.renci.org/')
 SAPBERT_ANNOTATE_ENDPOINT = urllib.parse.urljoin(SAPBERT_URL, '/annotate/')
 SAPBERT_MODEL_NAME = "sapbert"
 SAPBERT_COUNT = 1000  # We've found that 1000 is about the minimum you need for reasonable results.


### PR DESCRIPTION
This PR updates the SAPBERT URL to our new Qdrant-based endpoint.

It also adds support for including 'None', 'NA' and other values in the Biolink type field, which will be ignored, adds `biolink:` to Biolink types that don't have that, and increase the default SAPBERT limit to 10.